### PR TITLE
[IN-58] Builds supporting new 5th generation EC2 instances

### DIFF
--- a/bootstrapvz/base/manifest-schema.yml
+++ b/bootstrapvz/base/manifest-schema.yml
@@ -59,6 +59,7 @@ properties:
         type: string
         pattern: ^\S+$
       locale: {type: string}
+      pnin: {type: boolean}
       release: {type: string}
       timezone: {type: string}
     required:

--- a/bootstrapvz/common/assets/extlinux/extlinux.conf
+++ b/bootstrapvz/common/assets/extlinux/extlinux.conf
@@ -10,12 +10,12 @@ timeout 50
 label l0
 	menu label Debian GNU/Linux, kernel {kernel_version}
 	linux {boot_prefix}/vmlinuz-{kernel_version}
-	append initrd={boot_prefix}/initrd.img-{kernel_version} root=UUID={root_uuid} ro quiet console=ttyS0
+	append initrd={boot_prefix}/initrd.img-{kernel_version} root=UUID={root_uuid} ro quiet console=ttyS0 {disable_pnin}
 
 label l0r
 	menu label Debian GNU/Linux, kernel {kernel_version} (recovery mode)
 	linux {boot_prefix}/vmlinuz-{kernel_version}
-	append initrd={boot_prefix}/initrd.img-{kernel_version} root=UUID={root_uuid} ro console=ttyS0 single
+	append initrd={boot_prefix}/initrd.img-{kernel_version} root=UUID={root_uuid} ro console=ttyS0 single {disable_pnin}
 	text help
    This option boots the system into recovery mode (single-user)
 	endtext

--- a/bootstrapvz/common/task_groups.py
+++ b/bootstrapvz/common/task_groups.py
@@ -161,6 +161,7 @@ def get_bootloader_group(manifest):
     from bootstrapvz.common.releases import jessie
     from bootstrapvz.common.releases import stretch
     group = []
+    pnin = manifest.system.get('pnin', None)
     if manifest.system['bootloader'] == 'grub':
         group.extend([grub.AddGrubPackage,
                       grub.InitGrubConfig,
@@ -173,7 +174,7 @@ def get_bootloader_group(manifest):
             group.append(grub.InstallGrub_1_99)
         else:
             group.append(grub.InstallGrub_2)
-        if manifest.release >= stretch:
+        if pnin is False or (pnin is None and manifest.release >= stretch):
             group.append(grub.DisablePNIN)
     if manifest.system['bootloader'] == 'extlinux':
         group.append(extlinux.AddExtlinuxPackage)

--- a/bootstrapvz/common/tasks/extlinux.py
+++ b/bootstrapvz/common/tasks/extlinux.py
@@ -4,6 +4,7 @@ from ..tools import log_check_call
 from . import filesystem
 from . import kernel
 from bootstrapvz.base.fs import partitionmaps
+from ..releases import stretch
 import os
 
 
@@ -74,6 +75,12 @@ class ConfigureExtlinuxJessie(Task):
             config_vars['boot_prefix'] = ''
         else:
             config_vars['boot_prefix'] = '/boot'
+
+        pnin = info.manifest.system.get('pnin', None)
+        if pnin is False or (pnin is None and info.manifest.release >= stretch):
+            config_vars['disable_pnin'] = 'net.ifnames=0 biosdevname=0'
+        else:
+            config_vars['disable_pnin'] = ''
 
         extlinux_config = extlinux_config_tpl.format(**config_vars)
 

--- a/bootstrapvz/providers/ec2/ebsvolume.py
+++ b/bootstrapvz/providers/ec2/ebsvolume.py
@@ -34,7 +34,7 @@ class EBSVolume(Volume):
         self.fsm.attach(instance_id=instance_id)
 
     def _before_attach(self, e):
-        import os
+        import os.path
         import string
         import urllib2
 

--- a/manifests/README.rst
+++ b/manifests/README.rst
@@ -162,6 +162,11 @@ system and does not fit under any other section.
 -  ``locale``: The default locale of the system.
    Valid values: Any locale mentioned in ``/etc/locale.gen``
    ``required``
+-  ``pnin``: Enable Persistent Network Interface Naming in the bootloader.
+   Only supported with the ``grub`` and ``extlinux`` bootloaders.
+   Valid values: ``true``, ``false``
+   Default: ``false``
+   ``optional``
 -  ``release``: Defines which debian release should be bootstrapped.
    Valid values: ``wheezy``, ``jessie``, ``stretch``, ``sid``,
    ``oldstable``, ``stable``, ``testing``, ``unstable``


### PR DESCRIPTION
[IN-58 A base Debian 9 (stretch) AMI is needed to build Quicket AMIs](https://quicketsolutions.atlassian.net/browse/IN-58)

Merging yet un-merged PR's from upstream to allow building images on and for the new C5 instance types with extlinux support for an unpartitioned root volume.